### PR TITLE
Additional swagger client settings

### DIFF
--- a/lib/puppet/provider/harbor_project/swagger.rb
+++ b/lib/puppet/provider/harbor_project/swagger.rb
@@ -64,6 +64,10 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new
@@ -81,6 +85,10 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new

--- a/lib/puppet/provider/harbor_project/swagger.rb
+++ b/lib/puppet/provider/harbor_project/swagger.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   desc 'Swagger API implementation for harbor projects'
 
   def self.instances
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     projects = api_instance.projects_get
 
@@ -74,29 +74,8 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
     api_instance
   end
 
-  def do_login
-    require 'yaml'
-    require 'harbor_swagger_client'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-
-    SwaggerClient.configure do |config|
-      config.username = my_config['username']
-      config.password = my_config['password']
-      config.scheme = my_config['scheme']
-      config.verify_ssl = my_config['verify_ssl']
-      config.verify_ssl_host = my_config['verify_ssl_host']
-      config.ssl_ca_cert = my_config['ssl_ca_cert']
-      if my_config['host']
-        config.host = my_config['host']
-      end
-    end
-
-    api_instance = SwaggerClient::ProductsApi.new
-    api_instance
-  end
-
   def exists?
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: resource[:name],
@@ -124,7 +103,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def create
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     np = SwaggerClient::ProjectReq.new(project_name: resource[:name], metadata: { public: resource[:public] })
 
@@ -148,7 +127,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def public=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_project_id_by_name(resource[:name])
 
@@ -166,7 +145,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def members
-    api_instance = do_login
+    api_instance = self.class.do_login
     id = get_project_id_by_name(resource[:name])
     members = api_instance.projects_project_id_members_get(id)
     member_arry = []
@@ -193,7 +172,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def member_groups
-    api_instance = do_login
+    api_instance = self.class.do_login
     id = get_project_id_by_name(resource[:name])
     members = api_instance.projects_project_id_members_get(id)
     member_arry = []
@@ -221,7 +200,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
 
 
   def get_project_id_by_name(project_name)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: project_name,
@@ -233,7 +212,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def get_current_project_members(id)
-    api_instance = do_login
+    api_instance = self.class.do_login
     members = api_instance.projects_project_id_members_get(id)
     member_arry = []
     members.each do |member|
@@ -246,7 +225,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def get_current_project_member_groups(id)
-    api_instance = do_login
+    api_instance = self.class.do_login
     members = api_instance.projects_project_id_members_get(id)
     member_arry = []
     members.each do |member|
@@ -259,7 +238,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def add_members_to_project(id, members)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     members.sort!
     members.each do |member|
@@ -273,7 +252,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def add_member_groups_to_project(id, member_groups)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     member_groups.sort!
     member_groups.each do |group|
@@ -288,7 +267,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def get_usergroup_id_by_name(group)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     ug = api_instance.usergroups_get()
     group.downcase!
@@ -297,7 +276,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def remove_members_from_project(id, members_to_delete)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     members_to_delete.sort!
     members_to_delete.each do |member|
@@ -307,7 +286,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def remove_member_groups_from_project(id, member_groups_to_delete)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     member_groups_to_delete.sort!
     member_groups_to_delete.each do |member_group|
@@ -317,7 +296,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def get_project_member_id_by_name(id, member)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       entityname: member,
@@ -328,7 +307,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   end
 
   def destroy
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: resource[:name],

--- a/lib/puppet/provider/harbor_project/swagger.rb
+++ b/lib/puppet/provider/harbor_project/swagger.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:harbor_project).provide(:swagger) do
   desc 'Swagger API implementation for harbor projects'
 
   def self.instances
-    api_instance = self.class.do_login
+    api_instance = do_login
 
     projects = api_instance.projects_get
 

--- a/lib/puppet/provider/harbor_registry/swagger.rb
+++ b/lib/puppet/provider/harbor_registry/swagger.rb
@@ -42,6 +42,10 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new
@@ -59,6 +63,10 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new

--- a/lib/puppet/provider/harbor_registry/swagger.rb
+++ b/lib/puppet/provider/harbor_registry/swagger.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   desc 'Swagger API implementation for harbor registries'
 
   def self.instances
-    api_instance = self.class.do_login
+    api_instance = do_login
 
     registries = api_instance.registries_get
 

--- a/lib/puppet/provider/harbor_registry/swagger.rb
+++ b/lib/puppet/provider/harbor_registry/swagger.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   desc 'Swagger API implementation for harbor registries'
 
   def self.instances
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     registries = api_instance.registries_get
 
@@ -52,29 +52,8 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
     api_instance
   end
 
-  def do_login
-    require 'yaml'
-    require 'harbor_swagger_client'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-
-    SwaggerClient.configure do |config|
-      config.username = my_config['username']
-      config.password = my_config['password']
-      config.scheme = my_config['scheme']
-      config.verify_ssl = my_config['verify_ssl']
-      config.verify_ssl_host = my_config['verify_ssl_host']
-      config.ssl_ca_cert = my_config['ssl_ca_cert']
-      if my_config['host']
-        config.host = my_config['host']
-      end
-    end
-
-    api_instance = SwaggerClient::ProductsApi.new
-    api_instance
-  end
-
   def exists?
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: resource[:name],
@@ -94,7 +73,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def create
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     if resource[:insecure]
       insecure_bool = cast_to_bool(resource[:insecure].to_s)
@@ -121,7 +100,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def set_registry_credential(id) # rubocop:disable Style/AccessorMethodName
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     repo_target = SwaggerClient::PutRegistry.new(access_key: resource[:access_key], access_secret: resource[:access_secret])
 
@@ -138,7 +117,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def get_registry_id_by_name(registry_name)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: registry_name,
@@ -154,7 +133,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def description=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_registry_id_by_name(resource[:name])
 
@@ -168,7 +147,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def insecure=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_registry_id_by_name(resource[:name])
 
@@ -184,7 +163,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def url=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_registry_id_by_name(resource[:name])
 
@@ -198,7 +177,7 @@ Puppet::Type.type(:harbor_registry).provide(:swagger) do
   end
 
   def destroy
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     registry_id = get_registry_id_by_name(resource[:name])
 

--- a/lib/puppet/provider/harbor_replication_policy/swagger.rb
+++ b/lib/puppet/provider/harbor_replication_policy/swagger.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   desc 'Swagger API implementation for harbor replication policies'
 
   def self.instances
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     replication_policies = api_instance.replication_policies_get
 
@@ -71,29 +71,8 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
     api_instance
   end
 
-  def do_login
-    require 'yaml'
-    require 'harbor_swagger_client'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-
-    SwaggerClient.configure do |config|
-      config.username = my_config['username']
-      config.password = my_config['password']
-      config.scheme = my_config['scheme']
-      config.verify_ssl = my_config['verify_ssl']
-      config.verify_ssl_host = my_config['verify_ssl_host']
-      config.ssl_ca_cert = my_config['ssl_ca_cert']
-      if my_config['host']
-        config.host = my_config['host']
-      end
-    end
-
-    api_instance = SwaggerClient::ProductsApi.new
-    api_instance
-  end
-
   def get_replication_policy_id_by_name(replication_policy_name)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: replication_policy_name,
@@ -109,7 +88,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def exists?
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: resource[:name],
@@ -134,7 +113,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def get_registry_id_by_name(registry_name)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: registry_name,
@@ -150,7 +129,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def get_registry_info_by_name(registry_name)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: registry_name,
@@ -180,7 +159,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def create
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     if resource[:deletion]
       deletion_bool = cast_to_bool(resource[:deletion].to_s)
@@ -232,7 +211,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def update_replication_policy_param(resource)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     if resource[:deletion]
       deletion_bool = cast_to_bool(resource[:deletion].to_s)
@@ -312,7 +291,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   end
 
   def destroy
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     replication_policy_id = get_replication_policy_id_by_name(resource[:name])
 

--- a/lib/puppet/provider/harbor_replication_policy/swagger.rb
+++ b/lib/puppet/provider/harbor_replication_policy/swagger.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
   desc 'Swagger API implementation for harbor replication policies'
 
   def self.instances
-    api_instance = self.class.do_login
+    api_instance = do_login
 
     replication_policies = api_instance.replication_policies_get
 

--- a/lib/puppet/provider/harbor_replication_policy/swagger.rb
+++ b/lib/puppet/provider/harbor_replication_policy/swagger.rb
@@ -61,6 +61,10 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new
@@ -78,6 +82,10 @@ Puppet::Type.type(:harbor_replication_policy).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new

--- a/lib/puppet/provider/harbor_system_label/swagger.rb
+++ b/lib/puppet/provider/harbor_system_label/swagger.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   desc 'Swagger API implementation for harbor system-level labels'
 
   def self.instances
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     labels = api_instance.labels_get('g')
 
@@ -49,29 +49,8 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
     api_instance
   end
 
-  def do_login
-    require 'yaml'
-    require 'harbor_swagger_client'
-    my_config = YAML.load_file('/etc/puppetlabs/swagger.yaml')
-
-    SwaggerClient.configure do |config|
-      config.username = my_config['username']
-      config.password = my_config['password']
-      config.scheme = my_config['scheme']
-      config.verify_ssl = my_config['verify_ssl']
-      config.verify_ssl_host = my_config['verify_ssl_host']
-      config.ssl_ca_cert = my_config['ssl_ca_cert']
-      if my_config['host']
-        config.host = my_config['host']
-      end
-    end
-
-    api_instance = SwaggerClient::ProductsApi.new
-    api_instance
-  end
-
   def get_label_id_by_name(label_name)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: label_name,
@@ -87,7 +66,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def name=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_label_id_by_name(resource[:name])
 
@@ -105,7 +84,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def description=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_label_id_by_name(resource[:name])
 
@@ -123,7 +102,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def color=(_value)
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     id = get_label_id_by_name(resource[:name])
 
@@ -141,7 +120,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def exists?
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     opts = {
       name: resource[:name],
@@ -161,7 +140,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def create
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     nl = SwaggerClient::Label.new(name: resource[:name], description: resource[:description], color: resource[:color], scope: 'g')
 
@@ -173,7 +152,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   end
 
   def destroy
-    api_instance = do_login
+    api_instance = self.class.do_login
 
     label_id = get_label_id_by_name(resource[:name])
 

--- a/lib/puppet/provider/harbor_system_label/swagger.rb
+++ b/lib/puppet/provider/harbor_system_label/swagger.rb
@@ -39,6 +39,10 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new
@@ -56,6 +60,10 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new

--- a/lib/puppet/provider/harbor_system_label/swagger.rb
+++ b/lib/puppet/provider/harbor_system_label/swagger.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:harbor_system_label).provide(:swagger) do
   desc 'Swagger API implementation for harbor system-level labels'
 
   def self.instances
-    api_instance = self.class.do_login
+    api_instance = do_login
 
     labels = api_instance.labels_get('g')
 

--- a/lib/puppet/provider/harbor_user_settings/swagger.rb
+++ b/lib/puppet/provider/harbor_user_settings/swagger.rb
@@ -15,6 +15,10 @@ Puppet::Type.type(:harbor_user_settings).provide(:swagger) do
       config.scheme = my_config['scheme']
       config.verify_ssl = my_config['verify_ssl']
       config.verify_ssl_host = my_config['verify_ssl_host']
+      config.ssl_ca_cert = my_config['ssl_ca_cert']
+      if my_config['host']
+        config.host = my_config['host']
+      end
     end
 
     api_instance = SwaggerClient::ProductsApi.new


### PR DESCRIPTION
These changes allow to enable 'verify_ssl' when a self-signed certificate is invloved. Therefore it is required to point out to a certificate bundle with parameter 'ssl_ca_cert'.
Additionally the parameter 'host' can be set which then allow to enable 'verify_ss_host'.