### PR TITLE
Added parameter 'type' to resource 'harbor_registry'

### DIFF
--- a/lib/puppet/type/harbor_registry.rb
+++ b/lib/puppet/type/harbor_registry.rb
@@ -31,8 +31,8 @@ DESC
 
   newparam(:set_credential) do
     desc 'Whether to set the credential for the registry'
-    defaultto :false
     newvalues(:true, :false)
+    defaultto :false
   end
 
   newparam(:access_key) do
@@ -45,7 +45,12 @@ DESC
 
   newproperty(:insecure) do
     desc 'Whether or not the certificate will be verified when Harbor tries to access the server'
-    defaultto :false
     newvalues(:true, :false)
+    defaultto :false
+  end
+
+  newparam(:type) do
+    desc 'Type of the registry, e.g. "harbor", "gitlab".'
+    defaultto 'harbor'
   end
 end

--- a/spec/unit/puppet/provider/harbor_registry/swagger_spec.rb
+++ b/spec/unit/puppet/provider/harbor_registry/swagger_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:harbor_registry).provider(:swagger) do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      describe 'when validating class interface' do
+        [ :instances, :prefetch ].each do |method|
+          it "should have a method \"#{method}\"" do
+            expect(described_class).to respond_to :method
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/harbor_registry_spec.rb
+++ b/spec/unit/puppet/type/harbor_registry_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:harbor_registry) do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      describe 'when validating attributes' do
+        [ :name, :set_credential, :access_key, :access_secret, :type ].each do |param|
+          it "should have a parameter '#{param}'" do
+            expect(described_class.attrtype(param)).to eq(:param)
+          end
+        end
+        [ :ensure, :description, :url, :insecure ].each do |prop|
+          it "should have a property '#{prop}'" do
+            expect(described_class.attrtype(prop)).to eq(:property)
+          end
+        end
+      end
+
+      describe "namevar validation" do
+        it "should have :name as its namevar" do
+          expect(described_class.key_attributes).to eq([:name])
+        end
+      end
+
+      describe 'when validating attribute values' do
+        describe 'ensure' do
+          [ :present, :absent ].each do |value|
+            it "should support value '#{value}'" do
+              expect { described_class.new({
+                :name   => 'the_name',
+                :ensure => value,
+              })}.to_not raise_error
+            end
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name   => 'the_name',
+              :ensure => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+
+        describe "set_credential" do
+          [ 'false', 'true' ].each do |value|
+            it "should support value '#{value}'" do
+              expect { described_class.new({
+                :name           => 'the_name',
+                :set_credential => value,
+              }) }.to_not raise_error
+            end
+          end
+
+          it "should default to false" do
+            expect(described_class.new({
+              :name => 'the_name'
+            })[:set_credential]).to eq :false
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name           => 'the_name',
+              :set_credential => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+
+        describe "insecure" do
+          [ 'false', 'true' ].each do |value|
+            it "should support value '#{value}'" do
+              expect { described_class.new({
+                :name           => 'the_name',
+                :insecure => value,
+              }) }.to_not raise_error
+            end
+          end
+
+          it "should default to false" do
+            expect(described_class.new({
+              :name => 'the_name'
+            })[:insecure]).to eq :false
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name     => 'the_name',
+              :insecure => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+
+        describe "type" do
+          it "should default to 'harbor'" do
+            expect(described_class.new({
+              :name => 'the_name'
+            })[:type]).to eq 'harbor'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added parameter 'type' to resource 'harbor_registry' in order to define the type of the registry endpoint, e.g. 'harbor', 'gitlab'. Set default value of parameter 'type' to previously hard-coded value 'harbor'. Additionally split much code in small methods in order to allow reuse and remove duplicated code, and improve readability and understanding.