### PR TITLE
Avoid calling map() on nil object in provider of resource harbor_project

### DIFF
--- a/spec/unit/puppet/type/harbor_project_spec.rb
+++ b/spec/unit/puppet/type/harbor_project_spec.rb
@@ -9,12 +9,12 @@ describe Puppet::Type.type(:harbor_project) do
 
       describe 'when validating attributes' do
         [ :name ].each do |param|
-          it "should have a parameter \"#{param}\"" do
+          it "should have a parameter '#{param}'" do
             expect(described_class.attrtype(param)).to eq(:param)
           end
         end
-        [ :public, :members, :member_groups ].each do |prop|
-          it "should have a property \"#{prop}\"" do
+        [ :ensure, :public, :members, :member_groups ].each do |prop|
+          it "should have a property '#{prop}'" do
             expect(described_class.attrtype(prop)).to eq(:property)
           end
         end
@@ -29,7 +29,7 @@ describe Puppet::Type.type(:harbor_project) do
       describe 'when validating attribute values' do
         describe 'ensure' do
           [ :present, :absent ].each do |value|
-            it "should support \"#{value}\" as a value to \"ensure\"" do
+            it "should support value '#{value}'" do
               expect { described_class.new({
                 :name   => 'the_project',
                 :ensure => value,
@@ -47,7 +47,7 @@ describe Puppet::Type.type(:harbor_project) do
 
         describe "public" do
           [ 'false', 'true' ].each do |value|
-            it "should support '#{value}' as a value for \"public\"" do
+            it "should support value '#{value}'" do
               expect { described_class.new({
                 :name   => 'the_project',
                 :public => value,


### PR DESCRIPTION
Resolved issue in self.instances() when calling map() on nil object which is returned by api_instance.projects_get() if there are no registries.
Added filtering of returned projects by api_instance.projects_get() for a for given 'name'. This is required because api_instance.projects_get() returns also projects which contain the given name partly, e.g. 'demo push' will also be returned when asking for 'demo' beside.

Renamed variables and methods in order to distinguish if SwaggerClient's ProjectMemberEntity objects or simple member/member_group names are used.
In general split much code in small methods in order to allow reuse and remove duplicated code, and improve readability and understanding.

Slightly reworked 'describe' texts in tests.