### PR TITLE
Resolved issues when creating replication policies

### DIFF
--- a/lib/puppet/type/harbor_replication_policy.rb
+++ b/lib/puppet/type/harbor_replication_policy.rb
@@ -11,7 +11,7 @@ Puppet::Type.newtype(:harbor_replication_policy) do
       enabled          => true,
       override         => false,
       replication_mode => 'pull',
-      remote_registry  => 'UPSTREAM'
+      remote_registry  => 'UPSTREAM',
       filters          => [{'type' => 'name', 'value' => 'exampleproject/**'}, {'type' => 'tag', 'value' => '*'}],
       trigger          => {type => "scheduled", trigger_settings => {cron => "0 0 15 * * *"}},
     }
@@ -39,10 +39,11 @@ DESC
 
   newproperty(:dest_namespace) do
     desc 'The destination namespace'
+    defaultto ''
   end
 
   newproperty(:trigger) do
-    desc 'Trigger type and trigger settings for policy'
+    desc 'Trigger type and trigger settings for policy. type can be "manual", "scheduled", "event_based". "scheduled" requires "trigger_settings" dictionary with "cron" key point to string, e.g. "0 0 15 * * *".'
   end
 
   newproperty(:filters, array_matching: :all) do
@@ -50,14 +51,20 @@ DESC
   end
 
   newproperty(:deletion) do
-    desc 'Whether to replicate the deletion operation'
+    desc 'Whether to replicate the deletion operation. Requires trigger "event_based" in order to enable.'
+    newvalues(:true, :false)
+    defaultto :false
   end
 
   newproperty(:override) do
     desc 'Whether to override the resources on the destination registry'
+    newvalues(:true, :false)
+    defaultto :false
   end
 
   newproperty(:enabled) do
     desc 'Whether the policy is enabled or not'
+    newvalues(:true, :false)
+    defaultto :true
   end
 end

--- a/spec/unit/puppet/provider/harbor_replication_policy/swagger_spec.rb
+++ b/spec/unit/puppet/provider/harbor_replication_policy/swagger_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:harbor_replication_policy).provider(:swagger) do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      describe 'when validating class interface' do
+        [ :instances, :prefetch ].each do |method|
+          it "should have a method \"#{method}\"" do
+            expect(described_class).to respond_to :method
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/harbor_replication_policy_spec.rb
+++ b/spec/unit/puppet/type/harbor_replication_policy_spec.rb
@@ -1,0 +1,156 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:harbor_replication_policy) do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      describe 'when validating attributes' do
+        [ :name, :remote_registry, :replication_mode,  ].each do |param|
+          it "should have a parameter '#{param}'" do
+            expect(described_class.attrtype(param)).to eq(:param)
+          end
+        end
+        [ :deletion, :description, :dest_namespace, :enabled, :ensure, :filters, :override, :trigger ].each do |prop|
+          it "should have a property '#{prop}'" do
+            expect(described_class.attrtype(prop)).to eq(:property)
+          end
+        end
+      end
+
+      describe "namevar validation" do
+        it "should have :name as its namevar" do
+          expect(described_class.key_attributes).to eq([:name])
+        end
+      end
+
+      describe 'when validating attribute values' do
+        describe 'ensure' do
+          [ :present, :absent ].each do |value|
+            it "should support value '#{value}'" do
+              expect { described_class.new({
+                :name   => 'the_name',
+                :ensure => value,
+              })}.to_not raise_error
+            end
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name   => 'the_name',
+              :ensure => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+
+        describe "description" do
+          it "should default to ''" do
+            expect(described_class.new({
+              :name => 'the_name'
+            })[:description]).to eq ''
+          end
+        end
+
+        describe "dest_namespace" do
+          it "should default to ''" do
+            expect(described_class.new({
+              :name => 'the_name'
+            })[:dest_namespace]).to eq ''
+          end
+        end
+
+        describe "replication_mode" do
+          [ 'push', 'pull' ].each do |value|
+            it "should support value '#{value}'" do
+              expect { described_class.new({
+                :name             => 'the_name',
+                :replication_mode => value,
+              }) }.to_not raise_error
+            end
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name             => 'the_name',
+              :replication_mode => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+
+        describe "deletion" do
+          [ false, true ].each do |value|
+            it "should support value '#{value}'" do
+              expect { described_class.new({
+                :name     => 'the_name',
+                :deletion => value,
+              }) }.to_not raise_error
+            end
+          end
+
+          it "should default to :false" do
+            expect(described_class.new({
+              :name => 'the_name'
+            })[:deletion]).to eq :false
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name     => 'the_name',
+              :deletion => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+
+        describe "override" do
+          [ false, true ].each do |value|
+            it "should support value '#{value}'" do
+              expect { described_class.new({
+                :name     => 'the_name',
+                :override => value,
+              }) }.to_not raise_error
+            end
+          end
+
+          it "should default to :false" do
+            expect(described_class.new({
+              :name => 'the_name'
+            })[:override]).to eq :false
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name     => 'the_name',
+              :override => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+
+        describe "enabled" do
+          [ false, true ].each do |value|
+            it "should support value '#{value}'" do
+              expect { described_class.new({
+                :name    => 'the_name',
+                :enabled => value,
+              }) }.to_not raise_error
+            end
+          end
+
+          it "should default to :true" do
+            expect(described_class.new({
+              :name => 'the_name'
+            })[:enabled]).to eq :true
+          end
+
+          it "should not support other values" do
+            expect { described_class.new({
+              :name    => 'the_name',
+              :enabled => 'other_value',
+            })}.to raise_error(Puppet::Error, /Invalid value/)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolved some issues which occurred when creating replication policies from scratch differing from the documented example, e.g. trigger or filters.

Defined explicit values ':false',':true' for boolean like properties 'deletion', 'override', 'enabled'.
Set default value '' for property 'description'.
Added documentation for property 'trigger'.

Only read key 'trigger_settings' if available.
Added filtering of returned policies by api_instance.replication_policies_get() for a for given 'name'. This is required because api_instance.replication_policies_get() returns also policies which contain the given name partly, e.g. 'demo push' will also be returned when asking for 'demo'.
Implemented provider's interface method 'flush' because all properties when changed have been applied together in update_replication_policy_param(). In opposite to previous implementation of single 'property=()' methods the flush() method is automatically called ONLY once if several properties change. This reduces executions of the SwaggerClient.

In general split much code in small methods in order to allow reuse and remove duplicated code, and improve readability and understanding.
Renamed variables and methods in order to distinguish if SwaggerClient's ProjectMemberEntity objects or simple member/member_group names are used.

Added some unit tests.